### PR TITLE
Fix status endpoint showing zero values

### DIFF
--- a/src/bot/commands.py
+++ b/src/bot/commands.py
@@ -207,13 +207,14 @@ async def status_command(message: Message, state: FSMContext):
     user_projects = await project_queue.get_user_projects(user_id)
     queue_stats = project_queue.get_queue_stats()
     
-    if user_projects or queue_stats['total_projects'] > 0:
+    if user_projects or queue_stats['total_projects'] > 0 or queue_stats['total_processed'] > 0:
         status_info += f"""
 
 **📊 Черга проектів:**
 **Ваші проекти:** {len(user_projects)}
-**Загальна черга:** В черзі: {queue_stats['queued']}, Обробляється: {queue_stats['processing']}
-**Завершено:** {queue_stats['completed']}, Помилки: {queue_stats['failed']}
+**Поточна черга:** В черзі: {queue_stats['queued']}, Обробляється: {queue_stats['processing']}
+**Загальна статистика:** Завершено: {queue_stats['completed']}, Помилки: {queue_stats['failed']}
+**Всього оброблено:** {queue_stats['total_processed']} проектів
 """
     
     await message.answer(status_info, parse_mode="Markdown")
@@ -247,7 +248,8 @@ async def queue_command(message: Message):
     queue_text += f"• Обробляється: {queue_stats['processing']}\n"
     queue_text += f"• Завершено: {queue_stats['completed']}\n"
     queue_text += f"• Помилки: {queue_stats['failed']}\n"
-    queue_text += f"• Всього проектів: {queue_stats['total_projects']}\n\n"
+    queue_text += f"• Активних проектів: {queue_stats['total_projects']}\n"
+    queue_text += f"• Всього оброблено: {queue_stats['total_processed']}\n\n"
     
     if user_projects:
         # Sort projects by creation time


### PR DESCRIPTION
Add persistent counters for completed and failed projects to ensure accurate statistics are displayed even after project cleanup.

Previously, the `/status` command only reported on currently active projects. Projects that were completed or failed and subsequently removed by the `cleanup_old_projects` method (after 24 hours) were no longer counted, leading to the `/status` command showing 0 for these categories. This PR introduces dedicated counters that persist across cleanups, providing a true historical count of processed projects.

---
<a href="https://cursor.com/background-agent?bcId=bc-60302bd7-46e7-48ce-8eba-282394ab0bfb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-60302bd7-46e7-48ce-8eba-282394ab0bfb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

